### PR TITLE
The config option "max-chapter" should be parsed as an integer.

### DIFF
--- a/txt2mobi/utilities.py
+++ b/txt2mobi/utilities.py
@@ -69,7 +69,7 @@ class ProjectConfig(object):
     @property
     def max_chapter(self):
         try:
-            return self.cf.get('book', 'max-chapter')
+            return self.cf.getint('book', 'max-chapter')
         except:
             return 1500
 


### PR DESCRIPTION
Related issue link: https://github.com/ipconfiger/txt2mobi/issues/1

Change-Id: Ic34f956f9a77abd50ea5d2ac19b759ef5f0b4e5a